### PR TITLE
fix(sentry): ajout du type HeaderSectionChamp dans le fragment ChampInfo

### DIFF
--- a/app/lib/mes_demarches.rb
+++ b/app/lib/mes_demarches.rb
@@ -233,6 +233,9 @@ module MesDemarches
       ... on FormuleChamp {
           value
       }
+      ... on HeaderSectionChamp {
+          stringValue
+      }
     }
 
     fragment DossierInfo on Dossier {


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/INSPECTEUR-FA
Occurrences (24h) : 9916
Environnement : production

## Analyse
Le fragment GraphQL `ChampInfo` (dans `app/lib/mes_demarches.rb`) ne déclarait pas le type `HeaderSectionChamp`. Quand l'API Demarches-Simplifiées retourne des annotations de ce type (séparateur de section), le gem `graphql-client` lève une `InvariantError` car le type n'est pas dans les `possible_types` du fragment. Le `schema.json` local listait déjà `HeaderSectionChamp` comme implémentation de l'interface `Champ`.

## Fix
Ajout de `... on HeaderSectionChamp { stringValue }` dans le fragment `ChampInfo` de `app/lib/mes_demarches.rb`.

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain

---
🤖 PR générée automatiquement par claude sentry-triage