### PR TITLE
chore(deps): upgrader devise 4.9.4 -> 5.0.4 (CVEs)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'csv'
 gem 'delayed_cron_job' # Cron jobs
 gem 'delayed_job_active_record'
 gem 'delayed_job_web'
-gem 'devise', '~> 4.7'
+gem 'devise', '~> 5.0'
 gem 'devise-i18n'
 gem 'docx', '~> 0.8.0'
 gem 'fugit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,14 +156,14 @@ GEM
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
       sinatra (>= 1.4.4)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.15.0)
-      devise (>= 4.9.0)
+    devise-i18n (1.16.0)
+      devise (>= 5.0.0)
       rails-i18n
     diff-lcs (1.6.2)
     docx (0.8.0)
@@ -233,7 +233,7 @@ GEM
       concurrent-ruby (~> 1.0)
     iban-tools (1.2.1)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -385,7 +385,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -571,7 +571,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yajl-ruby (1.4.3)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   x86_64-darwin-22
@@ -591,7 +591,7 @@ DEPENDENCIES
   delayed_cron_job
   delayed_job_active_record
   delayed_job_web
-  devise (~> 4.7)
+  devise (~> 5.0)
   devise-i18n
   docx (~> 0.8.0)
   dotenv-rails


### PR DESCRIPTION
## Résumé

Bump majeur de Devise pour corriger les deux advisories restantes après PR #155 :
- Dependabot **#270** : Open Redirect via `request.referrer` dans Timeoutable Session Timeout Handler (`<= 5.0.3`)
- Dependabot **#221** : équivalent sur `<= 5.0.2`

Contrainte Gemfile : `~> 4.7` → `~> 5.0`. Bump aussi `devise-i18n` 1.15.0 → 1.16.0.

## Compat vérifiée

| Pré-requis Devise 5 | État projet |
|---|---|
| Ruby ≥ 2.7 | 3.4.4 ✅ |
| Rails ≥ 7.0 | 7.2.3.1 ✅ |

**APIs supprimées : aucune trouvée dans le code** (`grep` sur tout `app/`, `spec/`, `config/`):
- `devise_error_messages!` → les vues custom utilisent déjà `render "devise/shared/error_messages"`
- `Devise::TestHelpers`, `BLACKLIST_FOR_SERIALIZATION`, `SecretKeyFinder`, `Devise.activerecord51?`
- `sign_in(user, :scope)` positionnel, option `:bypass`

**Initializer** (`config/initializers/devise.rb`) : toutes les options actives sont supportées en 5.x.

## Test plan

- [x] `bundle exec rubocop --parallel` → 352 fichiers, 0 offense
- [x] `spec/lib/` + `spec/models/` : 469 exemples, 75 échecs **identiques à dev** (pré-existants, non liés)
- [x] `spec/models/user_spec.rb` : OK (le modèle User charge tous les modules devise sans erreur)
- [ ] Smoke manuel après merge : login, logout, reset password, email de confirmation

## ⚠️ Effet secondaire en prod

Devise 5 change la résolution de la clé secrète (utilise désormais uniquement `application.secret_key_base`). **Les tokens en cours émis avant le déploiement** (reset password, confirmation d'email, unlock) seront **invalidés**. Les utilisateurs en flux devront en redemander un. Communiquer si besoin.

Closes l'équivalent de la PR Dependabot #151 (à fermer après merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)