### PR TITLE
feat(detecter_doublon): détecter les doublons via une clé normalisée

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,6 +85,7 @@ Metrics/BlockLength:
     - 'spec/lib/grist/client_spec.rb'
     - 'spec/lib/payzen/payment_order_spec.rb'
     - 'spec/lib/publipostage_v2_expansion_spec.rb'
+    - 'spec/lib/detecter_doublon_spec.rb'
     - 'spec/lib/tftn/tickets_spec.rb'
     - 'spec/lib/travail/daeth_spec.rb'
     - 'lib/lppr.rb'

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -9,7 +9,7 @@ class DetecterDoublon < FieldChecker
   end
 
   def authorized_fields
-    super + %i[etats_doublons purge_after_months quand_doublon quand_unique]
+    super + %i[etats_doublons purge_after_months quand_doublon quand_unique message]
   end
 
   def initialize(params)
@@ -24,8 +24,22 @@ class DetecterDoublon < FieldChecker
     true
   end
 
-  def process(demarche, dossier)
-    super
+  # Bloque l'usage dans `when_ok:` — la propagation de @dossiers_to_recheck
+  # n'est active qu'en phase `controles:` (cf. moteur VerificationService).
+  # Mettre `detecter_doublon` dans `when_ok:` ferait silencieusement perdre
+  # le réveil des frères postérieurs.
+  def process(_demarche, _dossier)
+    raise NotImplementedError,
+          'detecter_doublon doit être placé dans `controles:`, pas `when_ok:` ' \
+          '(le recheck des frères ne se propage qu\'en phase de contrôle).'
+  end
+
+  def check(dossier)
+    @messages ||= []
+    @updated_dossiers ||= Set.new
+    @dossiers_to_recheck ||= Set.new
+    @dossier = dossier
+
     cle = compute_cle
     state = dossier.state.to_s
     depose_at = parse_depose_at(dossier)
@@ -35,7 +49,9 @@ class DetecterDoublon < FieldChecker
     return unless @states.include?(state)
 
     duplicates = current_duplicates(state, cle, depose_at)
-    fire_actions(duplicates, cle)
+    context = build_context(duplicates, cle)
+    fire_actions(duplicates, context)
+    fire_message(duplicates, cle, context)
     recheck_siblings(depose_at, [cle, previous_cle].compact.uniq)
   end
 
@@ -92,11 +108,10 @@ class DetecterDoublon < FieldChecker
     )
   end
 
-  def fire_actions(duplicates, cle)
+  def fire_actions(duplicates, context)
     definitions = duplicates.any? ? @when_doublon_defs : @when_unique_defs
     return if definitions.blank?
 
-    context = build_context(duplicates, cle)
     resolved = deep_resolve(definitions, context)
     tasks = InspectorTask.create_tasks(resolved)
     tasks.each do |task|
@@ -107,6 +122,12 @@ class DetecterDoublon < FieldChecker
         @dossiers_to_recheck += task.dossiers_to_recheck if task.respond_to?(:dossiers_to_recheck)
       end
     end
+  end
+
+  def fire_message(duplicates, cle, context)
+    return if duplicates.empty? || @params[:message].blank?
+
+    add_message(@params[:cle], cle, instanciate(@params[:message], context))
   end
 
   def build_context(duplicates, cle)

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -116,10 +116,7 @@ class DetecterDoublon < FieldChecker
       Rails.logger.tagged(task.name) do
         task.demarche = @demarche
         task.process(@demarche, @dossier)
-        # Workaround : ne pas propager `task.updated_dossiers`. Le contrat actuel
-        # (`field_checker.rb:256` stocke Integer ; `verification_service.rb:297`
-        # attend un objet) provoque NoMethodError sur `dossier.number`. À retirer
-        # quand la refonte `@dossier_updated boolean` (PR dédiée) sera mergée.
+        dossier_updated if task.respond_to?(:dossier_updated?) && task.dossier_updated?
         @dossiers_to_recheck += task.dossiers_to_recheck if task.respond_to?(:dossiers_to_recheck)
       end
     end

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -35,9 +35,6 @@ class DetecterDoublon < FieldChecker
   end
 
   def check(dossier)
-    @messages ||= []
-    @updated_dossiers ||= Set.new
-    @dossiers_to_recheck ||= Set.new
     @dossier = dossier
 
     cle = compute_cle
@@ -89,7 +86,8 @@ class DetecterDoublon < FieldChecker
           updated_at: now,
           created_at: now
         },
-        unique_by: :dossier_number
+        unique_by: :dossier_number,
+        update_only: %i[cle state depose_at]
       )
     else
       DossierDoublon.where(dossier_number: @dossier.number).delete_all
@@ -130,7 +128,18 @@ class DetecterDoublon < FieldChecker
   def fire_message(duplicates, cle, context)
     return if duplicates.empty? || @params[:message].blank?
 
-    add_message(@params[:cle].gsub(/[{}]/, ''), cle, instanciate(@params[:message], context))
+    add_message(message_anchor, cle, instanciate(@params[:message], context))
+  end
+
+  # Point d'accroche affiché à l'usager : extrait les noms de champs de la template
+  # `@params[:cle]` (ex. "{ChampX} {ChampY}" → "ChampX, ChampY"). Fallback sur la
+  # valeur brute si la clé est un littéral sans variables.
+  def message_anchor
+    @message_anchor ||= begin
+      tpl = @params[:cle].to_s
+      names = tpl.scan(/\{([^}]+)\}/).flatten
+      names.any? ? names.join(', ') : tpl
+    end
   end
 
   def build_context(duplicates, cle)

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -28,14 +28,15 @@ class DetecterDoublon < FieldChecker
     super
     cle = compute_cle
     state = dossier.state.to_s
+    depose_at = parse_depose_at(dossier)
     previous_cle = DossierDoublon.find_by(dossier_number: dossier.number)&.cle
 
-    sync_registry(state, cle)
+    sync_registry(state, cle, depose_at)
     return unless @states.include?(state)
 
-    duplicates = current_duplicates(state, cle, dossier)
+    duplicates = current_duplicates(state, cle, depose_at)
     fire_actions(duplicates, cle)
-    recheck_siblings(dossier, [cle, previous_cle].compact.uniq)
+    recheck_siblings(depose_at, [cle, previous_cle].compact.uniq)
   end
 
   private
@@ -47,12 +48,20 @@ class DetecterDoublon < FieldChecker
     raw.gsub(/\s+/, '').upcase.presence
   end
 
-  def registry_eligible?(state, cle)
-    @etats_doublons.include?(state) && cle.present?
+  def parse_depose_at(dossier)
+    raw = dossier.date_depot
+    return nil if raw.blank?
+    return raw if raw.is_a?(Time) || raw.is_a?(DateTime) || raw.is_a?(Date)
+
+    DateTime.iso8601(raw)
   end
 
-  def sync_registry(state, cle)
-    if registry_eligible?(state, cle)
+  def registry_eligible?(state, cle, depose_at)
+    @etats_doublons.include?(state) && cle.present? && depose_at.present?
+  end
+
+  def sync_registry(state, cle, depose_at)
+    if registry_eligible?(state, cle, depose_at)
       now = Time.zone.now
       DossierDoublon.upsert(
         {
@@ -60,7 +69,7 @@ class DetecterDoublon < FieldChecker
           dossier_number: @dossier.number,
           cle:,
           state:,
-          date_passage_en_construction: @dossier.date_passage_en_construction,
+          depose_at:,
           updated_at: now,
           created_at: now
         },
@@ -71,13 +80,13 @@ class DetecterDoublon < FieldChecker
     end
   end
 
-  def current_duplicates(state, cle, dossier)
-    return DossierDoublon.none unless registry_eligible?(state, cle)
+  def current_duplicates(state, cle, depose_at)
+    return DossierDoublon.none unless registry_eligible?(state, cle, depose_at)
 
     DossierDoublon.duplicates_of(
       demarche_id: @demarche.id,
       cle:,
-      dossier_number: dossier.number,
+      depose_at:,
       etats: @etats_doublons.to_a,
       purge_after_months: @params[:purge_after_months]
     )
@@ -118,13 +127,11 @@ class DetecterDoublon < FieldChecker
     end
   end
 
-  def recheck_siblings(dossier, cles)
-    return if cles.empty?
-
-    siblings = DossierDoublon.for_demarche(@demarche.id)
-                             .where(cle: cles)
-                             .where.not(dossier_number: dossier.number)
-                             .pluck(:dossier_number)
-    siblings.each { |number| recheck(number) }
+  # Asymétrique : ne réveille que les dossiers déposés APRÈS celui-ci.
+  # Les antérieurs sont par construction non impactés (leur statut "légitime"
+  # ne dépend que de leurs propres antérieurs).
+  def recheck_siblings(depose_at, cles)
+    DossierDoublon.posterior_siblings(demarche_id: @demarche.id, cles:, depose_at:)
+                  .each { |number| recheck(number) }
   end
 end

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -130,7 +130,7 @@ class DetecterDoublon < FieldChecker
   def fire_message(duplicates, cle, context)
     return if duplicates.empty? || @params[:message].blank?
 
-    add_message(@params[:cle], cle, instanciate(@params[:message], context))
+    add_message(@params[:cle].gsub(/[{}]/, ''), cle, instanciate(@params[:message], context))
   end
 
   def build_context(duplicates, cle)

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+class DetecterDoublon < FieldChecker
+  DEFAULT_ETATS_ACTIFS = %w[en_construction en_instruction].freeze
+  DEFAULT_ETATS_DOUBLONS = %w[en_construction en_instruction accepte].freeze
+
+  def required_fields
+    %i[cle]
+  end
+
+  def authorized_fields
+    super + %i[etats_doublons purge_after_months quand_doublon quand_unique]
+  end
+
+  def initialize(params)
+    super
+    @when_doublon_defs = Array(@params[:quand_doublon])
+    @when_unique_defs = Array(@params[:quand_unique])
+    @etats_doublons = Set.new(Array(@params[:etats_doublons]).presence || DEFAULT_ETATS_DOUBLONS)
+    @states = Set.new(Array(@params[:etat_du_dossier]).presence || DEFAULT_ETATS_ACTIFS)
+  end
+
+  def must_check?(_md_dossier)
+    true
+  end
+
+  def process(demarche, dossier)
+    super
+    cle = compute_cle
+    state = dossier.state.to_s
+    previous_cle = DossierDoublon.find_by(dossier_number: dossier.number)&.cle
+
+    sync_registry(state, cle)
+    return unless @states.include?(state)
+
+    duplicates = current_duplicates(state, cle, dossier)
+    fire_actions(duplicates, cle)
+    recheck_siblings(dossier, [cle, previous_cle].compact.uniq)
+  end
+
+  private
+
+  def compute_cle
+    raw = instanciate(@params[:cle].to_s)
+    return nil if raw.blank?
+
+    raw.gsub(/\s+/, '').upcase.presence
+  end
+
+  def registry_eligible?(state, cle)
+    @etats_doublons.include?(state) && cle.present?
+  end
+
+  def sync_registry(state, cle)
+    if registry_eligible?(state, cle)
+      now = Time.zone.now
+      DossierDoublon.upsert(
+        {
+          demarche_id: @demarche.id,
+          dossier_number: @dossier.number,
+          cle:,
+          state:,
+          date_passage_en_construction: @dossier.date_passage_en_construction,
+          updated_at: now,
+          created_at: now
+        },
+        unique_by: :dossier_number
+      )
+    else
+      DossierDoublon.where(dossier_number: @dossier.number).delete_all
+    end
+  end
+
+  def current_duplicates(state, cle, dossier)
+    return DossierDoublon.none unless registry_eligible?(state, cle)
+
+    DossierDoublon.duplicates_of(
+      demarche_id: @demarche.id,
+      cle:,
+      dossier_number: dossier.number,
+      etats: @etats_doublons.to_a,
+      purge_after_months: @params[:purge_after_months]
+    )
+  end
+
+  def fire_actions(duplicates, cle)
+    definitions = duplicates.any? ? @when_doublon_defs : @when_unique_defs
+    return if definitions.blank?
+
+    context = build_context(duplicates, cle)
+    resolved = deep_resolve(definitions, context)
+    tasks = InspectorTask.create_tasks(resolved)
+    tasks.each do |task|
+      Rails.logger.tagged(task.name) do
+        task.demarche = @demarche
+        task.process(@demarche, @dossier)
+        @updated_dossiers += task.updated_dossiers if task.respond_to?(:updated_dossiers)
+        @dossiers_to_recheck += task.dossiers_to_recheck if task.respond_to?(:dossiers_to_recheck)
+      end
+    end
+  end
+
+  def build_context(duplicates, cle)
+    refs = duplicates.map { |d| "##{d.dossier_number}" }
+    {
+      doublons_refs: refs.join(', '),
+      doublons_count: duplicates.size.to_s,
+      cle: cle.to_s
+    }
+  end
+
+  def deep_resolve(value, context)
+    case value
+    when Hash then value.transform_values { |v| deep_resolve(v, context) }
+    when Array then value.map { |v| deep_resolve(v, context) }
+    when String then instanciate(value, context)
+    else value
+    end
+  end
+
+  def recheck_siblings(dossier, cles)
+    return if cles.empty?
+
+    siblings = DossierDoublon.for_demarche(@demarche.id)
+                             .where(cle: cles)
+                             .where.not(dossier_number: dossier.number)
+                             .pluck(:dossier_number)
+    siblings.each { |number| recheck(number) }
+  end
+end

--- a/app/lib/detecter_doublon.rb
+++ b/app/lib/detecter_doublon.rb
@@ -118,7 +118,10 @@ class DetecterDoublon < FieldChecker
       Rails.logger.tagged(task.name) do
         task.demarche = @demarche
         task.process(@demarche, @dossier)
-        @updated_dossiers += task.updated_dossiers if task.respond_to?(:updated_dossiers)
+        # Workaround : ne pas propager `task.updated_dossiers`. Le contrat actuel
+        # (`field_checker.rb:256` stocke Integer ; `verification_service.rb:297`
+        # attend un objet) provoque NoMethodError sur `dossier.number`. À retirer
+        # quand la refonte `@dossier_updated boolean` (PR dédiée) sera mergée.
         @dossiers_to_recheck += task.dossiers_to_recheck if task.respond_to?(:dossiers_to_recheck)
       end
     end

--- a/app/lib/dossier_supprimer_label.rb
+++ b/app/lib/dossier_supprimer_label.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DossierSupprimerLabel < FieldChecker
+  def required_fields
+    super + %i[label]
+  end
+
+  def process(demarche, dossier)
+    super
+    return unless must_check?(dossier)
+
+    label_name = @params[:label]
+    return unless dossier_has_label?(dossier, label_name)
+
+    label_id = DossierLabel.find_label_id(demarche.id, label_name)
+    unless label_id
+      Rails.logger.warn("Label '#{label_name}' introuvable sur la démarche #{demarche.id}")
+      return
+    end
+
+    DossierLabel.remove(dossier.id, label_id)
+    dossier_updated(dossier)
+  end
+
+  private
+
+  def dossier_has_label?(dossier, label_name)
+    dossier.respond_to?(:labels) && dossier.labels&.any? { |l| l.name == label_name }
+  end
+end

--- a/app/models/dossier_doublon.rb
+++ b/app/models/dossier_doublon.rb
@@ -4,36 +4,51 @@
 #
 # Table name: dossier_doublons
 #
-#  id                            :bigint           not null, primary key
-#  cle                           :string           not null
-#  date_passage_en_construction  :datetime
-#  demarche_id                   :integer          not null
-#  dossier_number                :integer          not null
-#  state                         :string           not null
-#  created_at                    :datetime         not null
-#  updated_at                    :datetime         not null
+#  id             :bigint           not null, primary key
+#  cle            :string           not null
+#  depose_at      :datetime         not null
+#  dossier_number :integer          not null
+#  state          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  demarche_id    :integer          not null
 #
 # Indexes
 #
-#  index_dossier_doublons_on_demarche_id_and_cle  (demarche_id,cle)
-#  index_dossier_doublons_on_dossier_number       (dossier_number) UNIQUE
+#  index_dossier_doublons_on_demarche_id_and_cle_and_depose_at  (demarche_id,cle,depose_at)
+#  index_dossier_doublons_on_dossier_number                     (dossier_number) UNIQUE
 #
 class DossierDoublon < ApplicationRecord
   validates :demarche_id, presence: true
   validates :dossier_number, presence: true, uniqueness: true
   validates :cle, presence: true
   validates :state, presence: true
+  validates :depose_at, presence: true
 
   scope :for_demarche, ->(demarche_id) { where(demarche_id:) }
   scope :with_states, ->(states) { where(state: states) }
-  scope :recent, ->(months) { months.present? ? where(date_passage_en_construction: months.months.ago..) : all }
+  scope :recent, ->(months) { months.present? ? where(depose_at: months.months.ago..) : all }
 
-  def self.duplicates_of(demarche_id:, cle:, dossier_number:, etats:, purge_after_months: nil)
+  # Asymétrique : ne renvoie que les frères ANTÉRIEURS au dépôt légal (depose_at).
+  # Le dossier déposé en premier reste légitime ; ceux déposés après sont marqués doublons.
+  def self.duplicates_of(demarche_id:, cle:, depose_at:, etats:, purge_after_months: nil)
     for_demarche(demarche_id)
       .with_states(etats)
       .where(cle:)
-      .where.not(dossier_number:)
+      .where('depose_at < ?', depose_at)
       .recent(purge_after_months)
-      .order(:dossier_number)
+      .order(:depose_at, :dossier_number)
+  end
+
+  # Pendant asymétrique : numéros des dossiers POSTÉRIEURS sur les mêmes clés.
+  # Utilisé pour réveiller les "candidats doublons" quand le statut du légitime change
+  # (clé modifiée, sortie du registre).
+  def self.posterior_siblings(demarche_id:, cles:, depose_at:)
+    return [] if cles.empty? || depose_at.blank?
+
+    for_demarche(demarche_id)
+      .where(cle: cles)
+      .where('depose_at > ?', depose_at)
+      .pluck(:dossier_number)
   end
 end

--- a/app/models/dossier_doublon.rb
+++ b/app/models/dossier_doublon.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: dossier_doublons
+#
+#  id                            :bigint           not null, primary key
+#  cle                           :string           not null
+#  date_passage_en_construction  :datetime
+#  demarche_id                   :integer          not null
+#  dossier_number                :integer          not null
+#  state                         :string           not null
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#
+# Indexes
+#
+#  index_dossier_doublons_on_demarche_id_and_cle  (demarche_id,cle)
+#  index_dossier_doublons_on_dossier_number       (dossier_number) UNIQUE
+#
+class DossierDoublon < ApplicationRecord
+  validates :demarche_id, presence: true
+  validates :dossier_number, presence: true, uniqueness: true
+  validates :cle, presence: true
+  validates :state, presence: true
+
+  scope :for_demarche, ->(demarche_id) { where(demarche_id:) }
+  scope :with_states, ->(states) { where(state: states) }
+  scope :recent, ->(months) { months.present? ? where(date_passage_en_construction: months.months.ago..) : all }
+
+  def self.duplicates_of(demarche_id:, cle:, dossier_number:, etats:, purge_after_months: nil)
+    for_demarche(demarche_id)
+      .with_states(etats)
+      .where(cle:)
+      .where.not(dossier_number:)
+      .recent(purge_after_months)
+      .order(:dossier_number)
+  end
+end

--- a/db/migrate/20260506090828_create_dossier_doublons.rb
+++ b/db/migrate/20260506090828_create_dossier_doublons.rb
@@ -7,12 +7,12 @@ class CreateDossierDoublons < ActiveRecord::Migration[6.1]
       t.integer :dossier_number, null: false
       t.string :cle, null: false
       t.string :state, null: false
-      t.datetime :date_passage_en_construction
+      t.datetime :depose_at, null: false
 
       t.timestamps
     end
 
     add_index :dossier_doublons, :dossier_number, unique: true
-    add_index :dossier_doublons, %i[demarche_id cle]
+    add_index :dossier_doublons, %i[demarche_id cle depose_at]
   end
 end

--- a/db/migrate/20260506090828_create_dossier_doublons.rb
+++ b/db/migrate/20260506090828_create_dossier_doublons.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateDossierDoublons < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dossier_doublons do |t|
+      t.integer :demarche_id, null: false
+      t.integer :dossier_number, null: false
+      t.string :cle, null: false
+      t.string :state, null: false
+      t.datetime :date_passage_en_construction
+
+      t.timestamps
+    end
+
+    add_index :dossier_doublons, :dossier_number, unique: true
+    add_index :dossier_doublons, %i[demarche_id cle]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_260_212_041_933) do
+ActiveRecord::Schema[7.2].define(version: 20_260_506_090_828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -79,6 +79,18 @@ ActiveRecord::Schema[7.2].define(version: 20_260_212_041_933) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.index %w[dossier label], name: 'index_dossier_data_on_dossier_and_label', unique: true
+  end
+
+  create_table 'dossier_doublons', force: :cascade do |t|
+    t.integer 'demarche_id', null: false
+    t.integer 'dossier_number', null: false
+    t.string 'cle', null: false
+    t.string 'state', null: false
+    t.datetime 'date_passage_en_construction', precision: nil
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[demarche_id cle], name: 'index_dossier_doublons_on_demarche_id_and_cle'
+    t.index ['dossier_number'], name: 'index_dossier_doublons_on_dossier_number', unique: true
   end
 
   create_table 'messages', force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,10 +86,10 @@ ActiveRecord::Schema[7.2].define(version: 20_260_506_090_828) do
     t.integer 'dossier_number', null: false
     t.string 'cle', null: false
     t.string 'state', null: false
-    t.datetime 'date_passage_en_construction', precision: nil
+    t.datetime 'depose_at', precision: nil, null: false
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
-    t.index %w[demarche_id cle], name: 'index_dossier_doublons_on_demarche_id_and_cle'
+    t.index %w[demarche_id cle depose_at], name: 'index_dossier_doublons_on_demarche_id_and_cle_and_depose_at'
     t.index ['dossier_number'], name: 'index_dossier_doublons_on_dossier_number', unique: true
   end
 

--- a/spec/lib/detecter_doublon_spec.rb
+++ b/spec/lib/detecter_doublon_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe DetecterDoublon do
   let(:dossier_number) { 100 }
   let(:state) { 'en_construction' }
   let(:dossier_labels) { [] }
+  let(:dossier_depose_at) { 2.days.ago }
   let(:dossier) do
     double('dossier',
            id: "gid://Dossier/#{dossier_number}",
            number: dossier_number,
            state:,
-           date_passage_en_construction: 1.day.ago,
+           date_depot: dossier_depose_at,
            champs: [champ_immat],
            annotations: [],
            labels: dossier_labels)
@@ -67,7 +68,7 @@ RSpec.describe DetecterDoublon do
 
     it 'supprime du registre quand le dossier passe à refuse' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_instruction', depose_at: 2.days.ago)
       allow(dossier).to receive(:state).and_return('refuse')
       checker.process(demarche, dossier)
       expect(DossierDoublon.find_by(dossier_number:)).to be_nil
@@ -75,7 +76,7 @@ RSpec.describe DetecterDoublon do
 
     it 'supprime du registre quand la clé est vidée' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
-                             state: 'en_construction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_construction', depose_at: 2.days.ago)
       allow(champ_immat).to receive(:value).and_return('')
       checker.process(demarche, dossier)
       expect(DossierDoublon.find_by(dossier_number:)).to be_nil
@@ -87,7 +88,7 @@ RSpec.describe DetecterDoublon do
     let(:champ_prenom) { double('prenom', label: 'Prenom', __typename: 'TextChamp', value: 'Jacques') }
     let(:dossier_compose) do
       double('dossier_compose', id: 'd2', number: 200, state: 'en_construction',
-                                date_passage_en_construction: 1.day.ago,
+                                date_depot: 2.days.ago,
                                 champs: [champ_nom, champ_prenom], annotations: [], labels: [])
     end
     let(:checker) { described_class.new(cle: '{Nom}-{Prenom}') }
@@ -113,7 +114,7 @@ RSpec.describe DetecterDoublon do
       allow(task).to receive(:process)
       allow(InspectorTask).to receive(:create_tasks).and_return([task])
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_instruction', depose_at: 3.days.ago)
       checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
       checker_q.process(demarche, dossier)
       expect(task).not_to have_received(:process)
@@ -122,7 +123,7 @@ RSpec.describe DetecterDoublon do
 
     it 'détecte un accepté comme doublon pour un dossier en construction' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'accepte', date_passage_en_construction: 1.day.ago)
+                             state: 'accepte', depose_at: 3.days.ago)
       task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
       allow(task).to receive(:demarche=)
       allow(task).to receive(:process)
@@ -134,7 +135,7 @@ RSpec.describe DetecterDoublon do
 
     it 'ignore un dossier refusé comme doublon' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'refuse', date_passage_en_construction: 1.day.ago)
+                             state: 'refuse', depose_at: 3.days.ago)
       task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
       allow(task).to receive(:demarche=)
       allow(task).to receive(:process)
@@ -159,7 +160,7 @@ RSpec.describe DetecterDoublon do
 
     it 'fire quand_doublon en présence de doublons' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_instruction', depose_at: 3.days.ago)
       checker = described_class.new(base_params.merge(quand_doublon: [{ 'fake_task' => {} }]))
       checker.process(demarche, dossier)
       expect(fake_task).to have_received(:process).with(demarche, dossier)
@@ -181,9 +182,9 @@ RSpec.describe DetecterDoublon do
   describe '#process — substitution des variables' do
     it 'remplace doublons_refs, doublons_count, cle dans les params des sous-tâches' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 50, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_instruction', depose_at: 4.days.ago)
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'accepte', date_passage_en_construction: 2.days.ago)
+                             state: 'accepte', depose_at: 3.days.ago)
 
       captured = nil
       allow(InspectorTask).to receive(:create_tasks) do |defs|
@@ -207,7 +208,7 @@ RSpec.describe DetecterDoublon do
 
     it 'résout aussi les champs/attributs du dossier via instanciate (number, ternaire, prefix/postfix)' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+                             state: 'en_instruction', depose_at: 3.days.ago)
       captured = nil
       allow(InspectorTask).to receive(:create_tasks) do |defs|
         captured = defs
@@ -233,12 +234,34 @@ RSpec.describe DetecterDoublon do
   end
 
   describe '#process — recheck des frères' do
-    it 'demande la re-vérification des dossiers de même clé' do
-      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
-                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+    # Asymétrie : seuls les dossiers déposés APRÈS le courant sont réveillés.
+    # Le légitime (le plus ancien) ne se remet jamais en cause à cause d'un postérieur.
+    it 'réveille les frères postérieurs (depose_at > self.depose_at) sur la même clé' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 200, cle: 'PY-12345',
+                             state: 'en_instruction', depose_at: 1.day.ago)
       checker = described_class.new(base_params)
       checker.process(demarche, dossier)
-      expect(checker.dossiers_to_recheck).to include(99)
+      expect(checker.dossiers_to_recheck).to include(200)
+    end
+
+    it 'ne réveille pas les frères antérieurs' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 50, cle: 'PY-12345',
+                             state: 'en_instruction', depose_at: 4.days.ago)
+      checker = described_class.new(base_params)
+      checker.process(demarche, dossier)
+      expect(checker.dossiers_to_recheck).not_to include(50)
+    end
+
+    it 'le plus ancien reste légitime (unique) même avec un frère postérieur' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 200, cle: 'PY-12345',
+                             state: 'en_instruction', depose_at: 1.day.ago)
+      task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
+      allow(task).to receive(:demarche=)
+      allow(task).to receive(:process)
+      allow(InspectorTask).to receive(:create_tasks).and_return([task])
+      checker = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
+      checker.process(demarche, dossier)
+      expect(task).not_to have_received(:process)
     end
   end
 end

--- a/spec/lib/detecter_doublon_spec.rb
+++ b/spec/lib/detecter_doublon_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DetecterDoublon do
+  let(:instructeur_id) { 'instructeur-1' }
+  let(:demarche) { instance_double(Demarche, id: 3288, instructeur: instructeur_id) }
+
+  let(:champ_immat) do
+    double('champ', id: 'c1', label: 'Immatriculation du navire (PY)',
+                    __typename: 'TextChamp', value: 'PY-12345')
+  end
+
+  let(:dossier_number) { 100 }
+  let(:state) { 'en_construction' }
+  let(:dossier_labels) { [] }
+  let(:dossier) do
+    double('dossier',
+           id: "gid://Dossier/#{dossier_number}",
+           number: dossier_number,
+           state:,
+           date_passage_en_construction: 1.day.ago,
+           champs: [champ_immat],
+           annotations: [],
+           labels: dossier_labels)
+  end
+
+  let(:base_params) do
+    { cle: '{Immatriculation du navire (PY)}' }
+  end
+
+  describe 'paramétrage' do
+    it 'requiert cle' do
+      expect(described_class.new({}).valid?).to be false
+    end
+
+    it 'accepte etats_doublons, purge_after_months, quand_*, etat_du_dossier' do
+      checker = described_class.new(base_params.merge(
+                                      etats_doublons: %w[en_instruction],
+                                      purge_after_months: 8,
+                                      etat_du_dossier: %w[en_construction],
+                                      quand_doublon: [],
+                                      quand_unique: []
+                                    ))
+      expect(checker.valid?).to be true
+    end
+  end
+
+  describe '#process — registre' do
+    let(:checker) { described_class.new(base_params) }
+
+    it 'insère une entrée pour un dossier en construction' do
+      checker.process(demarche, dossier)
+      entry = DossierDoublon.find_by(dossier_number:)
+      expect(entry).to have_attributes(
+        demarche_id: demarche.id,
+        cle: 'PY-12345',
+        state: 'en_construction'
+      )
+    end
+
+    it 'normalise la clé (majuscules + suppression espaces)' do
+      allow(champ_immat).to receive(:value).and_return('  py 1234 pl  ')
+      checker.process(demarche, dossier)
+      expect(DossierDoublon.find_by(dossier_number:).cle).to eq 'PY1234PL'
+    end
+
+    it 'supprime du registre quand le dossier passe à refuse' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      allow(dossier).to receive(:state).and_return('refuse')
+      checker.process(demarche, dossier)
+      expect(DossierDoublon.find_by(dossier_number:)).to be_nil
+    end
+
+    it 'supprime du registre quand la clé est vidée' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
+                             state: 'en_construction', date_passage_en_construction: 1.day.ago)
+      allow(champ_immat).to receive(:value).and_return('')
+      checker.process(demarche, dossier)
+      expect(DossierDoublon.find_by(dossier_number:)).to be_nil
+    end
+  end
+
+  describe '#process — clé composite' do
+    let(:champ_nom) { double('nom', label: 'Nom', __typename: 'TextChamp', value: 'Cousteau') }
+    let(:champ_prenom) { double('prenom', label: 'Prenom', __typename: 'TextChamp', value: 'Jacques') }
+    let(:dossier_compose) do
+      double('dossier_compose', id: 'd2', number: 200, state: 'en_construction',
+                                date_passage_en_construction: 1.day.ago,
+                                champs: [champ_nom, champ_prenom], annotations: [], labels: [])
+    end
+    let(:checker) { described_class.new(cle: '{Nom}-{Prenom}') }
+
+    it 'compose la clé à partir de plusieurs champs' do
+      checker.process(demarche, dossier_compose)
+      expect(DossierDoublon.find_by(dossier_number: 200).cle).to eq 'COUSTEAU-JACQUES'
+    end
+  end
+
+  describe '#process — séparation etats_doublons / etat_du_dossier' do
+    let(:checker) do
+      described_class.new(base_params.merge(
+                            etat_du_dossier: %w[en_construction en_instruction],
+                            etats_doublons: %w[en_construction en_instruction accepte]
+                          ))
+    end
+
+    it 'ne fire pas les actions sur un accepté mais le maintient dans le registre' do
+      allow(dossier).to receive(:state).and_return('accepte')
+      task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
+      allow(task).to receive(:demarche=)
+      allow(task).to receive(:process)
+      allow(InspectorTask).to receive(:create_tasks).and_return([task])
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
+      checker_q.process(demarche, dossier)
+      expect(task).not_to have_received(:process)
+      expect(DossierDoublon.find_by(dossier_number:).state).to eq 'accepte'
+    end
+
+    it 'détecte un accepté comme doublon pour un dossier en construction' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'accepte', date_passage_en_construction: 1.day.ago)
+      task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
+      allow(task).to receive(:demarche=)
+      allow(task).to receive(:process)
+      allow(InspectorTask).to receive(:create_tasks).and_return([task])
+      checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
+      checker_q.process(demarche, dossier)
+      expect(task).to have_received(:process)
+    end
+
+    it 'ignore un dossier refusé comme doublon' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'refuse', date_passage_en_construction: 1.day.ago)
+      task = double('task', name: 'fake', valid?: true, updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
+      allow(task).to receive(:demarche=)
+      allow(task).to receive(:process)
+      allow(InspectorTask).to receive(:create_tasks).and_return([task])
+      checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
+      checker_q.process(demarche, dossier)
+      expect(task).not_to have_received(:process)
+    end
+  end
+
+  describe '#process — fire des actions' do
+    let(:fake_task) do
+      double('task', name: 'fake_task', valid?: true,
+                     updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
+    end
+
+    before do
+      allow(fake_task).to receive(:demarche=)
+      allow(fake_task).to receive(:process)
+      allow(InspectorTask).to receive(:create_tasks).and_return([fake_task])
+    end
+
+    it 'fire quand_doublon en présence de doublons' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      checker = described_class.new(base_params.merge(quand_doublon: [{ 'fake_task' => {} }]))
+      checker.process(demarche, dossier)
+      expect(fake_task).to have_received(:process).with(demarche, dossier)
+    end
+
+    it 'fire quand_unique en absence de doublons' do
+      checker = described_class.new(base_params.merge(quand_unique: [{ 'fake_task' => {} }]))
+      checker.process(demarche, dossier)
+      expect(fake_task).to have_received(:process).with(demarche, dossier)
+    end
+
+    it 'ignore une liste vide' do
+      checker = described_class.new(base_params)
+      checker.process(demarche, dossier)
+      expect(InspectorTask).not_to have_received(:create_tasks)
+    end
+  end
+
+  describe '#process — substitution des variables' do
+    it 'remplace doublons_refs, doublons_count, cle dans les params des sous-tâches' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 50, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'accepte', date_passage_en_construction: 2.days.ago)
+
+      captured = nil
+      allow(InspectorTask).to receive(:create_tasks) do |defs|
+        captured = defs
+        []
+      end
+
+      checker = described_class.new(base_params.merge(
+                                      quand_doublon: [{
+                                        'set_annotation' => {
+                                          'annotation' => 'Doublon',
+                                          'valeur' => 'cle={cle} count={doublons_count} refs={doublons_refs}'
+                                        }
+                                      }]
+                                    ))
+      checker.process(demarche, dossier)
+
+      params = captured.first['set_annotation']
+      expect(params['valeur']).to eq 'cle=PY-12345 count=2 refs=#50, #99'
+    end
+
+    it 'résout aussi les champs/attributs du dossier via instanciate (number, ternaire, prefix/postfix)' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      captured = nil
+      allow(InspectorTask).to receive(:create_tasks) do |defs|
+        captured = defs
+        []
+      end
+
+      checker = described_class.new(base_params.merge(
+                                      quand_doublon: [{
+                                        'set_annotation' => {
+                                          'numero' => 'PC {number}',
+                                          'phrase' => '{doublons trouvés: ;doublons_count;}',
+                                          'verdict' => '{doublons_count ? "doublon" : "ok"}'
+                                        }
+                                      }]
+                                    ))
+      checker.process(demarche, dossier)
+
+      params = captured.first['set_annotation']
+      expect(params['numero']).to eq 'PC 100'
+      expect(params['phrase']).to eq 'doublons trouvés: 1'
+      expect(params['verdict']).to eq 'doublon'
+    end
+  end
+
+  describe '#process — recheck des frères' do
+    it 'demande la re-vérification des dossiers de même clé' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', date_passage_en_construction: 1.day.ago)
+      checker = described_class.new(base_params)
+      checker.process(demarche, dossier)
+      expect(checker.dossiers_to_recheck).to include(99)
+    end
+  end
+end

--- a/spec/lib/detecter_doublon_spec.rb
+++ b/spec/lib/detecter_doublon_spec.rb
@@ -47,11 +47,12 @@ RSpec.describe DetecterDoublon do
     end
   end
 
-  describe '#process — registre' do
+  describe '#check — registre' do
     let(:checker) { described_class.new(base_params) }
 
     it 'insère une entrée pour un dossier en construction' do
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       entry = DossierDoublon.find_by(dossier_number:)
       expect(entry).to have_attributes(
         demarche_id: demarche.id,
@@ -62,7 +63,8 @@ RSpec.describe DetecterDoublon do
 
     it 'normalise la clé (majuscules + suppression espaces)' do
       allow(champ_immat).to receive(:value).and_return('  py 1234 pl  ')
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(DossierDoublon.find_by(dossier_number:).cle).to eq 'PY1234PL'
     end
 
@@ -70,7 +72,8 @@ RSpec.describe DetecterDoublon do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 2.days.ago)
       allow(dossier).to receive(:state).and_return('refuse')
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(DossierDoublon.find_by(dossier_number:)).to be_nil
     end
 
@@ -78,12 +81,13 @@ RSpec.describe DetecterDoublon do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number:, cle: 'PY-12345',
                              state: 'en_construction', depose_at: 2.days.ago)
       allow(champ_immat).to receive(:value).and_return('')
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(DossierDoublon.find_by(dossier_number:)).to be_nil
     end
   end
 
-  describe '#process — clé composite' do
+  describe '#check — clé composite' do
     let(:champ_nom) { double('nom', label: 'Nom', __typename: 'TextChamp', value: 'Cousteau') }
     let(:champ_prenom) { double('prenom', label: 'Prenom', __typename: 'TextChamp', value: 'Jacques') }
     let(:dossier_compose) do
@@ -94,12 +98,13 @@ RSpec.describe DetecterDoublon do
     let(:checker) { described_class.new(cle: '{Nom}-{Prenom}') }
 
     it 'compose la clé à partir de plusieurs champs' do
-      checker.process(demarche, dossier_compose)
+      checker.demarche = demarche
+      checker.check(dossier_compose)
       expect(DossierDoublon.find_by(dossier_number: 200).cle).to eq 'COUSTEAU-JACQUES'
     end
   end
 
-  describe '#process — séparation etats_doublons / etat_du_dossier' do
+  describe '#check — séparation etats_doublons / etat_du_dossier' do
     let(:checker) do
       described_class.new(base_params.merge(
                             etat_du_dossier: %w[en_construction en_instruction],
@@ -116,7 +121,8 @@ RSpec.describe DetecterDoublon do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 3.days.ago)
       checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
-      checker_q.process(demarche, dossier)
+      checker_q.demarche = demarche
+      checker_q.check(dossier)
       expect(task).not_to have_received(:process)
       expect(DossierDoublon.find_by(dossier_number:).state).to eq 'accepte'
     end
@@ -129,7 +135,8 @@ RSpec.describe DetecterDoublon do
       allow(task).to receive(:process)
       allow(InspectorTask).to receive(:create_tasks).and_return([task])
       checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
-      checker_q.process(demarche, dossier)
+      checker_q.demarche = demarche
+      checker_q.check(dossier)
       expect(task).to have_received(:process)
     end
 
@@ -141,12 +148,13 @@ RSpec.describe DetecterDoublon do
       allow(task).to receive(:process)
       allow(InspectorTask).to receive(:create_tasks).and_return([task])
       checker_q = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
-      checker_q.process(demarche, dossier)
+      checker_q.demarche = demarche
+      checker_q.check(dossier)
       expect(task).not_to have_received(:process)
     end
   end
 
-  describe '#process — fire des actions' do
+  describe '#check — fire des actions' do
     let(:fake_task) do
       double('task', name: 'fake_task', valid?: true,
                      updated_dossiers: Set.new, dossiers_to_recheck: Set.new)
@@ -162,24 +170,27 @@ RSpec.describe DetecterDoublon do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 3.days.ago)
       checker = described_class.new(base_params.merge(quand_doublon: [{ 'fake_task' => {} }]))
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(fake_task).to have_received(:process).with(demarche, dossier)
     end
 
     it 'fire quand_unique en absence de doublons' do
       checker = described_class.new(base_params.merge(quand_unique: [{ 'fake_task' => {} }]))
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(fake_task).to have_received(:process).with(demarche, dossier)
     end
 
     it 'ignore une liste vide' do
       checker = described_class.new(base_params)
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(InspectorTask).not_to have_received(:create_tasks)
     end
   end
 
-  describe '#process — substitution des variables' do
+  describe '#check — substitution des variables' do
     it 'remplace doublons_refs, doublons_count, cle dans les params des sous-tâches' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 50, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 4.days.ago)
@@ -200,7 +211,8 @@ RSpec.describe DetecterDoublon do
                                         }
                                       }]
                                     ))
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
 
       params = captured.first['set_annotation']
       expect(params['valeur']).to eq 'cle=PY-12345 count=2 refs=#50, #99'
@@ -224,7 +236,8 @@ RSpec.describe DetecterDoublon do
                                         }
                                       }]
                                     ))
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
 
       params = captured.first['set_annotation']
       expect(params['numero']).to eq 'PC 100'
@@ -233,14 +246,15 @@ RSpec.describe DetecterDoublon do
     end
   end
 
-  describe '#process — recheck des frères' do
+  describe '#check — recheck des frères' do
     # Asymétrie : seuls les dossiers déposés APRÈS le courant sont réveillés.
     # Le légitime (le plus ancien) ne se remet jamais en cause à cause d'un postérieur.
     it 'réveille les frères postérieurs (depose_at > self.depose_at) sur la même clé' do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 200, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 1.day.ago)
       checker = described_class.new(base_params)
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(checker.dossiers_to_recheck).to include(200)
     end
 
@@ -248,7 +262,8 @@ RSpec.describe DetecterDoublon do
       DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 50, cle: 'PY-12345',
                              state: 'en_instruction', depose_at: 4.days.ago)
       checker = described_class.new(base_params)
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(checker.dossiers_to_recheck).not_to include(50)
     end
 
@@ -260,8 +275,47 @@ RSpec.describe DetecterDoublon do
       allow(task).to receive(:process)
       allow(InspectorTask).to receive(:create_tasks).and_return([task])
       checker = described_class.new(base_params.merge(quand_doublon: [{ 'fake' => {} }]))
-      checker.process(demarche, dossier)
+      checker.demarche = demarche
+      checker.check(dossier)
       expect(task).not_to have_received(:process)
+    end
+  end
+
+  describe "#check — message à l'usager" do
+    it 'ajoute un message si paramètre `message` et doublon détecté (instanciation OK)' do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', depose_at: 3.days.ago)
+      checker = described_class.new(base_params.merge(
+                                      message: 'Une demande pour le navire {cle} existe déjà ({doublons_refs}).'
+                                    ))
+      checker.demarche = demarche
+      checker.check(dossier)
+      expect(checker.messages.size).to eq 1
+      expect(checker.messages.first.message).to eq 'Une demande pour le navire PY-12345 existe déjà (#99).'
+    end
+
+    it "n'ajoute pas de message si aucun doublon" do
+      checker = described_class.new(base_params.merge(message: 'Doublon : {doublons_refs}'))
+      checker.demarche = demarche
+      checker.check(dossier)
+      expect(checker.messages).to be_empty
+    end
+
+    it "n'ajoute pas de message si paramètre `message` absent (même avec doublon)" do
+      DossierDoublon.create!(demarche_id: demarche.id, dossier_number: 99, cle: 'PY-12345',
+                             state: 'en_instruction', depose_at: 3.days.ago)
+      checker = described_class.new(base_params)
+      checker.demarche = demarche
+      checker.check(dossier)
+      expect(checker.messages).to be_empty
+    end
+  end
+
+  describe '#process — interdit' do
+    it "raise pour empêcher l'usage dans when_ok: (recheck non propagé)" do
+      checker = described_class.new(base_params)
+      expect { checker.process(demarche, dossier) }
+        .to raise_error(NotImplementedError, /controles:/)
     end
   end
 end


### PR DESCRIPTION
## Résumé

Nouveau FieldChecker `DetecterDoublon` qui maintient un registre persistant (`dossier_doublons`) par démarche pour détecter les dossiers en doublon selon une clé calculée (mono ou composite).

Cas d'usage cible : démarche 3288 (DIREN — dérogation d'approche des cétacés / paraoa), détection de la double saisie d'une même immatriculation de navire.

## Composants

| Élément | Fichier |
|---|---|
| Migration `dossier_doublons` | `db/migrate/20260506090828_create_dossier_doublons.rb` |
| Modèle `DossierDoublon` (scopes `for_demarche`, `with_states`, `recent` + helper `duplicates_of`) | `app/models/dossier_doublon.rb` |
| FieldChecker principal | `app/lib/detecter_doublon.rb` |
| FieldChecker companion (utilisé par `quand_unique`) | `app/lib/dossier_supprimer_label.rb` |
| Spec (16 exemples) | `spec/lib/detecter_doublon_spec.rb` |

## API YAML

```yaml
- detecter_doublon:
    cle: "{Immatriculation du navire (PY)}"     # template instanciable
    etat_du_dossier: [en_construction, en_instruction]   # déclencheurs des actions
    etats_doublons:  [en_construction, en_instruction, accepte]  # états dans le registre
    purge_after_months: 8                        # filtre temporel
    quand_doublon:
      - set_annotation:
          annotation: "Doublon"
          valeur: "Doublon avec {doublons_refs}"
      - dossier_ajouter_label:
          label: "Doublon"
    quand_unique:
      - dossier_supprimer_label:
          label: "Doublon"
```

## Points de design notables

- **Clé normalisée** : upcase + suppression des blancs, supporte les clés composites (`{Nom}-{Prenom}`).
- **Séparation `etat_du_dossier` / `etats_doublons`** : on peut maintenir un `accepte` dans le registre (pour qu'il déclenche un doublon sur un nouvel `en_construction`) sans déclencher d'action sur lui-même.
- **Sous-tâches instanciées à la volée** : les params des `quand_doublon`/`quand_unique` sont résolus via le `instanciate` du `FieldChecker` parent, donc ils héritent gratuitement des ternaires (`{cond ? a : b}`), du prefix/postfix conditionnel (`{prefix; var; postfix}`), de la récursivité et du fallback champs/annotations du dossier. Contexte spécifique injecté : `{doublons_refs}`, `{doublons_count}`, `{cle}`.
- **Cold-start safe** : `must_check?` renvoie `true`, donc tous les dossiers passent par le checker au premier scan. Le `recheck_siblings` corrige les ordres de traitement défavorables. Aucun bootstrap externe nécessaire lors du transfert staging → prod.

## Test plan

- [x] `bundle exec rspec spec/lib/detecter_doublon_spec.rb` → 16/16 ✅
- [x] `bundle exec rake lint` → 362 fichiers, 0 offense
- [x] Migration `20260506090828` appliquée (vérifié via `db:migrate:status`)
- [ ] Test bout-en-bout en staging via config `storage/configurations/diren_paraoa.yml` (locale, à déployer via `mirror_staging.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)