### PR TITLE
refactor(check): @dossier_updated boolean + suppression du mail no-op

### DIFF
--- a/app/lib/conditional_field.rb
+++ b/app/lib/conditional_field.rb
@@ -71,9 +71,9 @@ class ConditionalField < FieldChecker
         when :calcul
           task.process_row(@dossier, @fields)
         end
-        @updated_dossiers += task.updated_dossiers
+        dossier_updated if task.dossier_updated?
         @dossiers_to_recheck += task.dossiers_to_recheck
-        @dossier = DossierActions.on_dossier(@dossier.number) if task.dossier_updated?(@dossier)
+        @dossier = DossierActions.on_dossier(@dossier.number) if task.dossier_updated?
       end
     end
   end

--- a/app/lib/daf/if_administration.rb
+++ b/app/lib/daf/if_administration.rb
@@ -55,7 +55,7 @@ module Daf
     def process_tasks(demarche, dossier)
       @tasks.each do |task|
         task.process(demarche, dossier) if task.valid? && task.must_check?(dossier)
-        dossier = DossierActions.on_dossier(dossier.number) if task.updated_dossiers.find { |d| d.number == dossier.number }.present?
+        dossier = DossierActions.on_dossier(dossier.number) if task.dossier_updated?
       end
     end
 

--- a/app/lib/daf/instruction.rb
+++ b/app/lib/daf/instruction.rb
@@ -140,9 +140,9 @@ module Daf
       tasks.each do |task|
         Rails.logger.info("Applying task #{task.class.name}")
         task.process(demarche, dossier) if task.valid?
-        @updated_dossiers += task.updated_dossiers
+        dossier_updated if task.dossier_updated?
         @dossiers_to_recheck += task.dossiers_to_recheck
-        dossier = DossierActions.on_dossier(dossier.number) if task.dossier_updated?(dossier)
+        dossier = DossierActions.on_dossier(dossier.number) if task.dossier_updated?
       end
     end
 

--- a/app/lib/field_checker.rb
+++ b/app/lib/field_checker.rb
@@ -2,42 +2,34 @@
 
 class FieldChecker < InspectorTask
   attr_accessor :dossier
-  attr_reader :messages, :accessed_fields, :updated_dossiers, :dossiers_to_recheck
+  attr_reader :messages, :accessed_fields, :dossiers_to_recheck
 
   attr_writer :demarche
 
   def initialize(params)
     super
-    @messages = []
-    @updated_dossiers = Set.new
-    @dossiers_to_recheck = Set.new
+    reset_state
     etat_du_dossier = @params[:etat_du_dossier] || ['en_construction']
     etat_du_dossier = etat_du_dossier.split(/\s*,\s*/) if etat_du_dossier.is_a?(String)
     @states = Set.new(etat_du_dossier)
   end
 
   def process(demarche, dossier)
-    @messages = []
-    @updated_dossiers = Set.new
-    @dossiers_to_recheck = Set.new
+    reset_state
     @dossier = dossier
     @demarche = demarche
-    # MicrosoftGraphCore::Authentication::OAuthAuthenticationProvider.new(context, nil, ['https://graph.microsoft.com/.default'])
-    #
-    # context = MicrosoftKiotaAuthenticationOAuth::ClientCredentialContext.new(tenant_id, user, password)
-    # authentication_provider = MicrosoftGraphCore::Authentication::OAuthAuthenticationProvider.new(context, nil, ['https://graph.microsoft.com/.default'])
-    # adapter = MicrosoftGraph::GraphRequestAdapter.new(authentication_provider)
-    # client = MicrosoftGraph::GraphServiceClient.new(adapter)
-    # client.sites.get.resume
   end
 
   def control(dossier)
-    @messages = []
-    @updated_dossiers = Set.new
-    @dossiers_to_recheck = Set.new
+    reset_state
     @dossier = dossier
-    @demarche = demarche
     check(dossier)
+  end
+
+  def reset_state
+    @messages = []
+    @dossiers_to_recheck = Set.new
+    @dossier_updated = false
   end
 
   def authorized_fields
@@ -252,12 +244,16 @@ class FieldChecker < InspectorTask
     @messages << Message.new(field: champ, value: valeur, message:)
   end
 
-  def dossier_updated(dossier)
-    @updated_dossiers << dossier.number
+  # Signale que LE DOSSIER COURANT a été modifié pendant ce check / process.
+  # L'argument est conservé pour rétrocompatibilité mais ignoré : tous les
+  # appelants (21 sites) passent le dossier courant, et tous les lecteurs
+  # (6 sites) ne testent que le dossier courant.
+  def dossier_updated(_dossier = nil)
+    @dossier_updated = true
   end
 
-  def dossier_updated?(dossier)
-    @updated_dossiers.include?(dossier.number)
+  def dossier_updated?(_dossier = nil)
+    @dossier_updated == true
   end
 
   def recheck(dossier)

--- a/app/lib/schedule.rb
+++ b/app/lib/schedule.rb
@@ -88,9 +88,9 @@ class Schedule < FieldChecker
         when :process
           task.process(@demarche, @dossier)
         end
-        @updated_dossiers += task.updated_dossiers
+        dossier_updated if task.dossier_updated?
         @dossiers_to_recheck += task.dossiers_to_recheck
-        @dossier = DossierActions.on_dossier(@dossier.number) if task.dossier_updated?(@dossier)
+        @dossier = DossierActions.on_dossier(@dossier.number) if task.dossier_updated?
       end
     end
   end

--- a/app/lib/verification_service.rb
+++ b/app/lib/verification_service.rb
@@ -262,13 +262,15 @@ class VerificationService
     @dossier_has_different_messages = false
     @second_time = false
     failed_checks = false
+    updated_dossier = nil
 
     controls.each do |control|
       check = check_control(control, demarche, md_dossier)
       checks << check
       failed_checks ||= check.failed
-      md_dossier = DossierActions.on_dossier(md_dossier.number) if control.dossier_updated?(md_dossier)
+      updated_dossier = md_dossier = DossierActions.on_dossier(md_dossier.number) if control.dossier_updated?
     end
+    avoid_useless_checks_for(updated_dossier) if updated_dossier
     unless failed_checks
       inform(md_dossier, checks, send_message: @send_messages) if @dossier_has_different_messages
       when_ok(demarche, md_dossier, checks) if @ok_tasks.present?
@@ -286,23 +288,21 @@ class VerificationService
         Rails.logger.info("task ask for processing = #{control_must_check}")
         apply_control(control, md_dossier, check) if control_must_check
         check.update(checked_at: start_time, version: control.version)
-        avoid_useless_checks(control)
         recheck_dependent_dossiers(control)
       end
       check
     end
   end
 
-  def avoid_useless_checks(control)
-    control.updated_dossiers.each do |dossier|
-      next unless dossier.present?
-
-      checked_at = Check.arel_table[:checked_at]
-      checkers = Check.where(dossier: dossier.number)
-                      .where(checked_at.gt(dossier.date_derniere_modification))
-      Rails.logger.debug("Checkers : #{checkers.map(&:checker).join(',')}")
-      checkers.update_all(checked_at: Time.zone.now)
-    end
+  # Marque les Checks du dossier dont la date_derniere_modification dépasse
+  # celle du dernier checked_at comme déjà à jour, pour éviter un re-traitement
+  # au prochain cycle. Appelé une seule fois, après la boucle des controls,
+  # avec la version la plus récente du dossier (rechargée).
+  def avoid_useless_checks_for(dossier)
+    checked_at = Check.arel_table[:checked_at]
+    Check.where(dossier: dossier.number)
+         .where(checked_at.gt(dossier.date_derniere_modification))
+         .update_all(checked_at: Time.zone.now)
   end
 
   def recheck_dependent_dossiers(control)
@@ -331,7 +331,10 @@ class VerificationService
       Check.find_or_create_by(dossier: md_dossier.number, checker: control.name) do |c|
         c.checked_at = EPOCH
         c.demarche = demarche
-        @dossier_has_different_messages = true # new check implies a message must be sent even if no error msg is triggered
+        # On NE force PAS @dossier_has_different_messages ici : un premier passage
+        # sans anomalie ne doit pas générer un mail "tout va bien" inutile.
+        # Le flag est positionné par update_check_messages (transition réelle
+        # d'anomalies) et ligne ~378 (transition failed -> ok).
       end
   end
 

--- a/spec/lib/generate_id_spec.rb
+++ b/spec/lib/generate_id_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe GenerateId do
       it 'marks dossier as updated' do
         checker.process(demarche, dossier)
 
-        expect(checker.updated_dossiers).to include(dossier.number)
+        expect(checker.dossier_updated?).to be true
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe GenerateId do
       it 'does not mark dossier as updated' do
         checker.process(demarche, dossier)
 
-        expect(checker.updated_dossiers).to be_empty
+        expect(checker.dossier_updated?).to be false
       end
     end
 


### PR DESCRIPTION
## Résumé

Deux optimisations orthogonales du moteur `VerificationService`, regroupées car elles touchent la même chaîne d'exécution.

### 1. Refonte `@updated_dossiers` (Set) → `@dossier_updated` (Boolean)

**Bug latent corrigé** : `field_checker.rb#dossier_updated` stockait `dossier.number` (Integer) mais `verification_service.rb#avoid_useless_checks` et `if_administration.rb` attendaient des objets dossier (`d.number`, `d.date_derniere_modification`). `NoMethodError 'number' for Integer` dès qu'un `FieldChecker` dans `controles:` propage les `updated_dossiers` de sous-tâches modifiantes.

**Audit** : 21 sites appellent `dossier_updated(...)`, tous passent le dossier courant. 6 sites lisent `dossier_updated?`, tous testent le dossier courant. Le `Set` est sur-dimensionné — un Boolean suffit.

**Modifs** :
- `FieldChecker` : Set → Boolean ; `dossier_updated(_dossier = nil)` et `dossier_updated?(_dossier = nil)` (args ignorés, rétrocompat). Factorisation de l'init dans `reset_state`.
- `conditional_field`, `schedule`, `daf/instruction`, `daf/if_administration` : `@updated_dossiers += task.updated_dossiers` → `dossier_updated if task.dossier_updated?`. Plus de fuite de variable d'instance entre wrapper et sous-tâche.
- `verification_service#apply_controls` : capture le dossier rechargé dans une **variable de boucle**, et appelle `avoid_useless_checks_for` **une seule fois** après la boucle avec la version finale (au lieu de N fois, une par control).

### 2. Suppression du mail no-op au premier passage

`verification_service.rb` ligne 334 forçait `@dossier_has_different_messages = true` à la création d'un Check → mail « tout va bien » envoyé même si aucune anomalie détectée. Du bruit.

Le mail légitime reste envoyé via :
- `update_check_messages` : transition réelle d'anomalies (vide → anomalie, anomalie → vide, anomalies différentes)
- `apply_control` ligne ~378 : transition `failed → ok`

Aucune config en prod ne tirait bénéfice du comportement précédent — bascule en comportement par défaut sans paramétrage.

## Test plan

- [x] `spec/lib/` : 465 exemples, 75 failures (= baseline `dev`, aucune régression). Diff entre `before` et `after` : 0 nouveau test cassé.
- [x] `generate_id_spec` adapté (testait `checker.updated_dossiers`, devient `checker.dossier_updated?`)
- [x] `rake lint` : 362 fichiers, 0 offense
- [ ] Smoke en staging avant prod

## À noter

Après merge de cette PR, le workaround dans `app/lib/detecter_doublon.rb` (PR #157, commit `070b2b2`) pourra être retiré : on pourra à nouveau propager `dossier_updated if task.dossier_updated?` depuis les sous-tâches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)