### PR TITLE
fix(sentry): utiliser champ_value pour lire l'annotation IntegerNumberChamp dans PaymentOrder

### DIFF
--- a/app/lib/payzen/payment_order.rb
+++ b/app/lib/payzen/payment_order.rb
@@ -59,7 +59,7 @@ module Payzen
       @dossier = dossier
       @demarche = demarche
 
-      montant = annotation(@params[:champ_montant])&.value || @params[:montant]
+      montant = champ_value(annotation(@params[:champ_montant])) || @params[:montant]
       return if montant.blank?
 
       montant = montant.to_i


### PR DESCRIPTION
## Contexte
Issue Sentry : https://idt.sentry.io/issues/INSPECTEUR-GA
Occurrences (24h) : 1795
Environnement : production

## Analyse
La méthode `process` de `Payzen::PaymentOrder` appelle `.value` sur l'annotation `champ_montant`. Quand cette annotation est de type `IntegerNumberChamp`, le client GraphQL lève `UnfetchedFieldError` car ce type expose `int_value` (pas `value`) dans le fragment de query.

La méthode `champ_value()` (héritée de `FieldChecker`) gère déjà correctement tous les types de champs, incluant `IntegerNumberChamp` → `int_value`.

## Fix
Remplacement de `annotation(...)&.value` par `champ_value(annotation(...))` à la ligne 62 de `app/lib/payzen/payment_order.rb`. Aucun autre fichier touché.

## Test plan
- [ ] CI verte
- [ ] Vérification manuelle par un humain

---
🤖 PR générée automatiquement par claude sentry-triage